### PR TITLE
Fix for issue #16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.12.4'
     testImplementation 'io.github.cdimascio:dotenv-java:3.0.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+    testImplementation 'org.wiremock:wiremock-standalone:3.13.1'
 }
 
 javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ if(hasProperty('target') && target == 'android') {
                  repositories {
              maven {
                  name = "Central"
-                 url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+                 url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
                  credentials {
                      username = project.findProperty("centralUsername") ?: System.getenv("CENTRAL_USERNAME")
                      password = project.findProperty("centralPassword") ?: System.getenv("CENTRAL_PASSWORD")

--- a/pom.xml
+++ b/pom.xml
@@ -36,15 +36,15 @@
       <url>https://developer.avalara.com/</url>
     </organization>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>central</id>
-            <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/</url>
-        </snapshotRepository>
+   <distributionManagement>
         <repository>
-            <id>central</id>
+            <id>ossrh</id>
             <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
+        </snapshotRepository>
     </distributionManagement>
     
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>central</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>central</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
     

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.avalara</groupId>
@@ -32,11 +33,11 @@
     </developers>
 
     <organization>
-      <name>Avalara</name>
-      <url>https://developer.avalara.com/</url>
+        <name>Avalara</name>
+        <url>https://developer.avalara.com/</url>
     </organization>
 
-   <distributionManagement>
+    <distributionManagement>
         <repository>
             <id>ossrh</id>
             <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
@@ -46,10 +47,23 @@
             <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </snapshotRepository>
     </distributionManagement>
-    
+
     <build>
         <plugins>
-           <plugin>
+            <!-- Central Publishing Maven Plugin for auto-release -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>ossrh</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
+                </configuration>
+            </plugin>
+            <!-- Compiler Plugin -->
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
@@ -59,10 +73,11 @@
                     <maxmem>512m</maxmem>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
-                        <arg>-J-Xss4m</arg><!-- Compiling the generated JSON.java file may require larger stack size. -->
+                        <arg>-J-Xss4m</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>
+            <!-- Enforcer Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -83,6 +98,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Surefire Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -99,6 +115,7 @@
                     <threadCount>10</threadCount>
                 </configuration>
             </plugin>
+            <!-- Dependency Plugin -->
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -113,7 +130,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- attach test jar -->
+            <!-- Jar Plugin for test-jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -125,9 +142,8 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                </configuration>
             </plugin>
+            <!-- Build Helper Plugin -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -159,6 +175,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Javadoc Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -182,6 +199,7 @@
                     </tags>
                 </configuration>
             </plugin>
+            <!-- Source Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -195,33 +213,28 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Use spotless plugin to automatically format code, remove unused import, etc
-                 To apply changes directly to the file, run `mvn spotless:apply`
-                 Ref: https://github.com/diffplug/spotless/tree/main/plugin-maven
-            -->
+            <!-- Spotless Plugin -->
             <plugin>
-              <groupId>com.diffplug.spotless</groupId>
-              <artifactId>spotless-maven-plugin</artifactId>
-              <version>${spotless.version}</version>
-              <configuration>
-                <formats>
-                  <!-- you can define as many formats as you want, each is independent -->
-                  <format>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <configuration>
+                    <formats>
+                        <format>
                     <!-- define the files to apply to -->
                     <includes>
                       <include>.gitignore</include>
                     </includes>
                     <!-- define the steps to apply to those files -->
-                    <trimTrailingWhitespace/>
-                    <endWithNewline/>
+                            <trimTrailingWhitespace/>
+                            <endWithNewline/>
                     <indent>
                       <spaces>true</spaces> <!-- or <tabs>true</tabs> -->
                       <spacesPerTab>4</spacesPerTab> <!-- optional, default is 4 -->
                     </indent>
-                  </format>
-                </formats>
-                <!-- define a language-specific format -->
-                <java>
+                        </format>
+                    </formats>
+                    <java>
                   <!-- no need to specify files, inferred automatically, but you can if you want -->
 
                   <!-- apply a specific flavor of google-java-format and reflow long strings -->
@@ -231,11 +244,10 @@
                     <reflowLongStrings>true</reflowLongStrings>
                   </googleJavaFormat>
 
-                  <removeUnusedImports/>
-                  <importOrder/>
-
-                </java>
-              </configuration>
+                        <removeUnusedImports/>
+                        <importOrder/>
+                    </java>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -270,7 +282,6 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
-        <!-- @Nullable annotation -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
@@ -343,7 +354,6 @@
             <artifactId>javax.ws.rs-api</artifactId>
             <version>${javax-version}</version>
         </dependency>
-        <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -357,6 +367,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <properties>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/src/main/java/Avalara/SDK/api/EInvoicing/V1/DocumentsApi.java
+++ b/src/main/java/Avalara/SDK/api/EInvoicing/V1/DocumentsApi.java
@@ -23,40 +23,23 @@ import Avalara.SDK.ApiCallback;
 import Avalara.SDK.ApiClient;
 import Avalara.SDK.ApiException;
 import Avalara.SDK.ApiResponse;
-import Avalara.SDK.Configuration;
-import Avalara.SDK.Pair;
-import Avalara.SDK.ProgressRequestBody;
-import Avalara.SDK.ProgressResponseBody;
 import Avalara.SDK.AvalaraMicroservice;
-
-
-import com.google.gson.reflect.TypeToken;
-
-import java.io.IOException;
-import java.util.*;
-
-
-import Avalara.SDK.model.EInvoicing.V1.BadDownloadRequest;
-import Avalara.SDK.model.EInvoicing.V1.BadRequest;
-import java.math.BigDecimal;
+import Avalara.SDK.Pair;
 import Avalara.SDK.model.EInvoicing.V1.DocumentFetch;
 import Avalara.SDK.model.EInvoicing.V1.DocumentListResponse;
 import Avalara.SDK.model.EInvoicing.V1.DocumentStatusResponse;
-import Avalara.SDK.model.EInvoicing.V1.DocumentSubmissionError;
 import Avalara.SDK.model.EInvoicing.V1.DocumentSubmitResponse;
-import Avalara.SDK.model.EInvoicing.V1.FetchDocumentsRequest;
-import java.io.File;
-import Avalara.SDK.model.EInvoicing.V1.ForbiddenError;
-import Avalara.SDK.model.EInvoicing.V1.InternalServerError;
-import Avalara.SDK.model.EInvoicing.V1.NotFoundError;
-import java.time.OffsetDateTime;
 import Avalara.SDK.model.EInvoicing.V1.SubmitDocumentMetadata;
-
+import com.google.gson.reflect.TypeToken;
+import java.io.File;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.MissingFormatArgumentException;
 
 public class DocumentsApi {
     private ApiClient localVarApiClient;
@@ -140,18 +123,18 @@ public class DocumentsApi {
 
         if (requestParameters.getAccept() != null) {
             localVarHeaderParams.put("Accept", localVarApiClient.parameterToString(requestParameters.getAccept()));
+        } else {
+            final String[] localVarAccepts = {
+                    "application/pdf", "application/xml", "application/json"
+            };
+            final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+            if (localVarAccept != null) {
+                localVarHeaderParams.put("Accept", localVarAccept);
+            }
         }
 
         if (requestParameters.getXAvalaraClient() != null) {
             localVarHeaderParams.put("X-Avalara-Client", localVarApiClient.parameterToString(requestParameters.getXAvalaraClient()));
-        }
-
-        final String[] localVarAccepts = {
-            "application/pdf", "application/xml", "application/json"
-        };
-        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
-        if (localVarAccept != null) {
-            localVarHeaderParams.put("Accept", localVarAccept);
         }
 
         final String[] localVarContentTypes = {

--- a/src/test/java/Avalara/SDK/api/A1099/V2/A1099Test.java
+++ b/src/test/java/Avalara/SDK/api/A1099/V2/A1099Test.java
@@ -1,27 +1,28 @@
 package Avalara.SDK.api.A1099.V2;
 
-import Avalara.SDK.*;
-import Avalara.SDK.api.A1099.V2.Issuers1099Api;
-import Avalara.SDK.api.A1099.V2.CompaniesW9Api;
-import Avalara.SDK.api.A1099.V2.Forms1099Api;
-import Avalara.SDK.api.A1099.V2.FormsW9Api;
-import Avalara.SDK.model.A1099.V2.*;
+import Avalara.SDK.ApiClient;
+import Avalara.SDK.AvaTaxEnvironment;
+import Avalara.SDK.Configuration;
+import Avalara.SDK.model.A1099.V2.PaginatedQueryResultModelCompanyResponse;
+import Avalara.SDK.model.A1099.V2.PaginatedQueryResultModelIssuerResponse;
 import io.github.cdimascio.dotenv.Dotenv;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * API tests for A1099 endpoints using JUnit.
  */
-public class A1099Test {
+class A1099Test {
+
     private ApiClient apiClient;
     private Issuers1099Api issuersApi;
     private CompaniesW9Api companiesApi;
     private Forms1099Api forms1099Api;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         // Load environment variables
         Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
 
@@ -41,7 +42,7 @@ public class A1099Test {
     }
 
     @Test
-    public void testGetIssuers() throws Exception {
+    void testGetIssuers() throws Exception {
         Issuers1099Api.GetIssuersRequest request = issuersApi.getGetIssuersRequest();
         request.set$top(10);
         request.set$skip(0);
@@ -49,12 +50,12 @@ public class A1099Test {
         request.setXCorrelationId("2bbbed41-2466-4cf6-9cca-a3258bdc8eba");
 
         PaginatedQueryResultModelIssuerResponse response = issuersApi.getIssuers(request);
-        Assert.assertNotNull(response);
-        Assert.assertNotNull(response.getValue());
+        Assertions.assertNotNull(response);
+        Assertions.assertNotNull(response.getValue());
     }
 
     @Test
-    public void testGetCompanies() throws Exception {
+    void testGetCompanies() throws Exception {
         CompaniesW9Api.GetCompaniesRequest request = companiesApi.getGetCompaniesRequest();
         request.set$top(10);
         request.set$skip(0);
@@ -62,31 +63,31 @@ public class A1099Test {
         request.setXCorrelationId("2bbbed41-2466-4cf6-9cca-a3258bdc8eba");
 
         PaginatedQueryResultModelCompanyResponse response = companiesApi.getCompanies(request);
-        Assert.assertNotNull(response);
-        Assert.assertNotNull(response.getValue());
+        Assertions.assertNotNull(response);
+        Assertions.assertNotNull(response.getValue());
     }
 
-    // @Test
-    // public void testList1099Forms() throws Exception {
-    // Forms1099Api.List1099FormsRequest request =
-    // forms1099Api.getList1099FormsRequest();
-    // request.set$top(10);
-    // request.set$skip(0);
-    // request.setXCorrelationId("2bbbed41-2466-4cf6-9cca-a3258bdc8eba");
-
-    // Form1099List response = forms1099Api.list1099Forms(request);
-    // Assert.assertNotNull(response);
-    // Assert.assertNotNull(response.getData());
-    // }
-
-    // @Test
-    // public void testListW9Forms() throws Exception {
-    // FormsW9Api.ListW9FormsRequest request = formsW9Api.getListW9FormsRequest();
-    // request.setTop(10);
-    // request.setSkip(0);
-
-    // ListW9FormsResponse response = formsW9Api.listW9Forms(request);
-    // Assert.assertNotNull(response);
-    // Assert.assertNotNull(response.getValue());
-    // }
+//    @Test
+//    void testList1099Forms() throws Exception {
+//        Forms1099Api.List1099FormsRequest request =
+//                forms1099Api.getList1099FormsRequest();
+//        request.set$top(10);
+//        request.set$skip(0);
+//        request.setXCorrelationId("2bbbed41-2466-4cf6-9cca-a3258bdc8eba");
+//
+//        Form1099List response = forms1099Api.list1099Forms(request);
+//        Assertions.assertNotNull(response);
+//        Assertions.assertNotNull(response.getData());
+//    }
+//
+//    @Test
+//    void testListW9Forms() throws Exception {
+//        FormsW9Api.ListW9FormsRequest request = formsW9Api.getListW9FormsRequest();
+//        request.setTop(10);
+//        request.setSkip(0);
+//
+//        ListW9FormsResponse response = formsW9Api.listW9Forms(request);
+//        Assertions.assertNotNull(response);
+//        Assertions.assertNotNull(response.getValue());
+//    }
 }

--- a/src/test/java/Avalara/SDK/api/ApiClientHelperTest.java
+++ b/src/test/java/Avalara/SDK/api/ApiClientHelperTest.java
@@ -23,12 +23,12 @@ package Avalara.SDK.api;
 import Avalara.SDK.*;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-public class ApiClientHelperTest {
-    private Configuration configuration;
+class ApiClientHelperTest {
+    private final Configuration configuration;
 
     public ApiClientHelperTest() {
         configuration = getConfiguration();
@@ -49,21 +49,21 @@ public class ApiClientHelperTest {
 
 
     @Test
-    @Ignore("Not currently supported")
-    public void verifyDeviceAuthorizationFlow() throws Exception {
+    @Disabled("Not currently supported")
+    void verifyDeviceAuthorizationFlow() throws Exception {
         DeviceAuthResponse response = ApiClientHelper.initiateDeviceAuthorizationOAuth(null, configuration);
         DeviceAccessTokenResponse tokenResponse = ApiClientHelper.getAccessTokenForDeviceFlow(response.getDeviceCode(), configuration);
-        Assert.assertEquals(tokenResponse.getErrorMessage(),"authorization_pending");
+        Assertions.assertEquals("authorization_pending", tokenResponse.getErrorMessage());
     }
 
     @Test
-    @Ignore("For this test to run, you need to authenticate manually using user code by pausing the flow at line 145 and then proceed")
-    public void verifyRefreshTokenFlow() throws Exception {
+    @Disabled("For this test to run, you need to authenticate manually using user code by pausing the flow at line 145 and then proceed")
+    void verifyRefreshTokenFlow() throws Exception {
         DeviceAuthResponse response = ApiClientHelper.initiateDeviceAuthorizationOAuth(null, configuration);
         DeviceAccessTokenResponse tokenResponse = ApiClientHelper.getAccessTokenForDeviceFlow(response.getDeviceCode(), configuration);
         String refreshToken = tokenResponse.getRefreshToken();
         tokenResponse = ApiClientHelper.getAccessTokenUsingRefreshTokenForDeviceCodeFlow(refreshToken, configuration);
-        Assert.assertNotNull(tokenResponse.getIdToken());
-        Assert.assertNotNull(tokenResponse.getAccessToken());
+        Assertions.assertNotNull(tokenResponse.getIdToken());
+        Assertions.assertNotNull(tokenResponse.getAccessToken());
     }
 }

--- a/src/test/java/Avalara/SDK/api/EInvoicing/V1/DocumentsApiTest.java
+++ b/src/test/java/Avalara/SDK/api/EInvoicing/V1/DocumentsApiTest.java
@@ -1,0 +1,141 @@
+package Avalara.SDK.api.EInvoicing.V1;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+
+import Avalara.SDK.ApiClient;
+import Avalara.SDK.ApiResponse;
+import Avalara.SDK.AvaTaxEnvironment;
+import Avalara.SDK.Configuration;
+import Avalara.SDK.api.EInvoicing.V1.DocumentsApi.DownloadDocumentRequest;
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.google.gson.reflect.TypeToken;
+import java.io.File;
+import java.util.List;
+import okhttp3.Call;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import wiremock.org.apache.commons.io.FileUtils;
+
+@WireMockTest
+class DocumentsApiTest {
+
+
+    public static final byte[] RESPONSE_CONTENT = "Example".getBytes();
+    public static final String TRANSACTION_ID = "transactionId";
+    public static final String X_AVALARA_CLIENT = "X_AVALARA_CLIENT";
+    public static final String AVALARA_VERSION = "1.3";
+    public static final String CONTENT_TYPE = "Content-Type";
+
+    @Test
+    void shouldDownloadDocumentWithoutInputCheckAndNoAcceptHeaderDefined(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        // given
+        // setup wiremock
+        String contentType = "application/json";
+        setUpWiremock_OkWithAcceptedHeader(contentType);
+
+        // create documentApi
+        DocumentsApi documentsApi = setupDocumentApi(wireMockRuntimeInfo);
+
+        // when
+        DownloadDocumentRequest request = documentsApi.getDownloadDocumentRequest();
+        request.setDocumentId(TRANSACTION_ID);
+        request.setXAvalaraClient(X_AVALARA_CLIENT);
+        request.setAvalaraVersion(AVALARA_VERSION);
+        Call call = documentsApi.downloadDocumentCall(request, null);
+        ApiResponse<File> fileApiResponse = documentsApi.getApiClient().execute(call, new TypeToken<File>() {}.getType());
+
+
+        // then
+        Assertions.assertEquals(200, fileApiResponse.getStatusCode());
+        Assertions.assertEquals(List.of(contentType), fileApiResponse.getHeaders().get(CONTENT_TYPE));
+        File file = fileApiResponse.getData();
+        byte[] bytes = FileUtils.readFileToByteArray(file);
+        Assertions.assertArrayEquals(RESPONSE_CONTENT, bytes);
+    }
+
+
+    @Test
+    void shouldDownloadDocumentWithHttpInfoAsPdf(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        // given
+        // setup wiremock
+        String contentType = "application/pdf";
+        setUpWiremock_OkWithAcceptedHeader(contentType);
+
+        // create documentApi
+        DocumentsApi documentsApi = setupDocumentApi(wireMockRuntimeInfo);
+
+        // when
+        DownloadDocumentRequest request = documentsApi.getDownloadDocumentRequest();
+        request.setDocumentId(TRANSACTION_ID);
+        request.setXAvalaraClient(X_AVALARA_CLIENT);
+        request.setAvalaraVersion(AVALARA_VERSION);
+        request.setAccept(contentType);
+        ApiResponse<File> fileApiResponse = documentsApi.downloadDocumentWithHttpInfo(request);
+
+        // then
+        Assertions.assertEquals(200, fileApiResponse.getStatusCode());
+        Assertions.assertEquals(List.of(contentType), fileApiResponse.getHeaders().get(CONTENT_TYPE));
+        File file = fileApiResponse.getData();
+        byte[] bytes = FileUtils.readFileToByteArray(file);
+        Assertions.assertArrayEquals(RESPONSE_CONTENT, bytes);
+    }
+
+    @Test
+    void shouldDownloadDocumentWithHttpInfoAsXml(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        // given
+        // setup wiremock
+        String contentType = "application/xml";
+        setUpWiremock_OkWithAcceptedHeader(contentType);
+
+        // create documentApi
+        DocumentsApi documentsApi = setupDocumentApi(wireMockRuntimeInfo);
+
+        // when
+        DownloadDocumentRequest request = documentsApi.getDownloadDocumentRequest();
+        request.setDocumentId(TRANSACTION_ID);
+        request.setXAvalaraClient(X_AVALARA_CLIENT);
+        request.setAvalaraVersion(AVALARA_VERSION);
+        request.setAccept(contentType);
+        ApiResponse<File> fileApiResponse = documentsApi.downloadDocumentWithHttpInfo(request);
+
+        // then
+        Assertions.assertEquals(200, fileApiResponse.getStatusCode());
+        Assertions.assertEquals(List.of(contentType), fileApiResponse.getHeaders().get(CONTENT_TYPE));
+        File file = fileApiResponse.getData();
+        byte[] bytes = FileUtils.readFileToByteArray(file);
+        Assertions.assertArrayEquals(RESPONSE_CONTENT, bytes);
+    }
+
+    private static DocumentsApi setupDocumentApi(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        String httpBaseUrl = wireMockRuntimeInfo.getHttpBaseUrl();
+        Configuration configuration = new Configuration();
+        String bearerToken = "BearerToken";
+        configuration.setBearerToken(bearerToken);
+        configuration.setAppName("AppName");
+        configuration.setAppVersion("1.0");
+        configuration.setMachineName("MachineName");
+        configuration.setTimeout(20000);
+        configuration.setEnvironment(AvaTaxEnvironment.Test);
+        configuration.setTokenUrl(httpBaseUrl);
+        configuration.setTestBasePath(httpBaseUrl);
+        ApiClient apiClient = new ApiClient(configuration);
+        DocumentsApi documentsApi = new DocumentsApi(apiClient);
+        return documentsApi;
+    }
+
+    private static void setUpWiremock_OkWithAcceptedHeader(String contentType) {
+        MappingBuilder mappingBuilder = WireMock.get(urlPathMatching("/einvoicing/documents/transactionId/\\$download"))
+                .withHeader("Accept", equalTo(contentType));
+        ResponseDefinitionBuilder responseBuilder = aResponse().withStatus(200)
+                .withHeader(CONTENT_TYPE, contentType)
+                .withBody(RESPONSE_CONTENT);
+        stubFor(mappingBuilder.willReturn(responseBuilder));
+    }
+}

--- a/src/test/java/Avalara/SDK/api/EInvoicing/V1/EInvoicingTest.java
+++ b/src/test/java/Avalara/SDK/api/EInvoicing/V1/EInvoicingTest.java
@@ -25,13 +25,13 @@ import Avalara.SDK.model.EInvoicing.V1.DocumentListResponse;
 import Avalara.SDK.model.EInvoicing.V1.MandatesResponse;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * API tests for UtilitiesApi
  */
-public class EInvoicingTest {
+class EInvoicingTest {
     private Configuration configuration;
 
     public EInvoicingTest() {
@@ -52,20 +52,20 @@ public class EInvoicingTest {
     }
 
     @Test
-    public void testGetDocuments() throws Exception {
+    void testGetDocuments() throws Exception {
         ApiClient apiClient = new ApiClient(configuration);
         Avalara.SDK.api.EInvoicing.V1.DocumentsApi apiInstance = new DocumentsApi(apiClient);
         DocumentsApi.GetDocumentListRequest request = apiInstance.getGetDocumentListRequest();
         DocumentListResponse result = apiInstance.getDocumentList(request);
-        Assert.assertNotNull(result);
+        Assertions.assertNotNull(result);
     }
 
     @Test
-    public void testGetMandates() throws Exception {
+    void testGetMandates() throws Exception {
         ApiClient apiClient = new ApiClient(configuration);
         Avalara.SDK.api.EInvoicing.V1.MandatesApi apiInstance = new MandatesApi(apiClient);
         MandatesApi.GetMandatesRequest request = apiInstance.getGetMandatesRequest();
         MandatesResponse result = apiInstance.getMandates(request);
-        Assert.assertNotNull(result.getValue());
+        Assertions.assertNotNull(result.getValue());
     }
 }


### PR DESCRIPTION
Hi there, 

I've fixed [Issue#16](https://github.com/avadev/Avalara-SDK-Java/issues/16).
If an Accept header is provided for document downloads, it will now be used; otherwise, it defaults to application/json.

I also migrated the existing tests to JUnit 5 and added new tests for this issue using WireMock.
Unfortunately, I wasn’t able to run the existing unit tests due to a missing .env file for Dotenv.
If possible, it would be great if you could add that file to the project.

Thanks!

